### PR TITLE
Add urql as GraphQL client and modify data-mocks Fetch.post for GraphQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "fetch-mock": "7.3.6",
+    "graphql": "^14.6.0",
+    "graphql-tag": "^2.10.3",
     "query-string": "^6.10.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "3.3.1",
     "typescript": "~3.7.2",
+    "urql": "^1.8.2",
     "xhr-mock": "2.4.1"
   },
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,21 @@
+import gql from 'graphql-tag';
 import React from 'react';
+import { useQuery } from 'urql';
+
 import logo from './logo.svg';
 import './App.css';
 
+const Query = gql`
+  query Query {
+    test
+  }
+`;
+
 const App = () => {
+  const [result] = useQuery({ query: Query });
+
+  console.log('GraphQL result', result);
+
   return (
     <div className="App">
       <header className="App-header">

--- a/src/data-mocks/mocks.ts
+++ b/src/data-mocks/mocks.ts
@@ -139,8 +139,9 @@ function handleGraphQLMock({ url, operations }: GraphQLMock) {
     return operations.find(o => o.operationName === operationName);
   };
   const findMockPost = postBody => {
+    const jsonBody = typeof postBody === 'string' ? JSON.parse(postBody) : postBody;
     return operations.find(
-      ({ operationName }) => operationName === postBody.operationName
+      ({ operationName }) => operationName === jsonBody.operationName
     );
   };
   const delayedResponse = (delay, response) => {
@@ -168,7 +169,7 @@ function handleGraphQLMock({ url, operations }: GraphQLMock) {
 
         FetchMock.post(
           url,
-          ({ body }) => {
+          (_, { body }) => {
             const mock = findMockPost(body);
 
             if (!mock) {
@@ -191,7 +192,7 @@ function handleGraphQLMock({ url, operations }: GraphQLMock) {
       case "mutation":
         FetchMock.post(
           url,
-          ({ body }) => {
+          (_, { body }) => {
             const mock = findMockPost(body);
 
             if (!mock) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { Provider, createClient } from "urql";
+
 import "./index.css";
 import App from "./App";
 
@@ -16,6 +18,15 @@ const mocks: Scenarios = {
       method: "GET",
       delay: 600,
       responseCode: 200
+    },
+    {
+      url: /graphql/,
+      method: 'GRAPHQL',
+      operations: [{
+        operationName: 'Query',
+        type: 'query',
+        response: { data: { test: 'test' } }
+      }],
     }
   ]
 };
@@ -30,4 +41,6 @@ fetch("http://example.com/test")
     console.log(myJson);
   });
 
-ReactDOM.render(<App />, document.getElementById("root"));
+const client = createClient({ url: 'http://example.com/graphql' });
+
+ReactDOM.render(<Provider value={client}><App /></Provider>, document.getElementById("root"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4654,6 +4654,18 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
+graphql-tag@^2.10.3:
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
+  integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
+
+graphql@^14.6.0:
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
+  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
+  dependencies:
+    iterall "^1.2.2"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -5497,6 +5509,11 @@ istanbul-reports@^2.2.6:
   integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
   dependencies:
     html-escaper "^2.0.0"
+
+iterall@^1.2.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jest-changed-files@^24.9.0:
   version "24.9.0"
@@ -8404,6 +8421,11 @@ react-scripts@3.3.1:
   optionalDependencies:
     fsevents "2.1.2"
 
+react-wonka@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-wonka/-/react-wonka-2.0.1.tgz#75bdf03dbad8ceb8c1066216f635f05ce2b642a5"
+  integrity sha512-mM2UH2gnK5LLzaqVWd6JCLrB1vO3I4PN/sQZbjvzsjms4vSv+nKwelNUftM0KeC+LtTPC4GGsuxyu2XJnsCUTw==
+
 react@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
@@ -8893,7 +8915,7 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@^0.18.0:
+"scheduler@>= 0.16.0", scheduler@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
   integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
@@ -9991,6 +10013,15 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+urql@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.8.2.tgz#66fcd111c346c45e647b7905fc6291e044425b06"
+  integrity sha512-ilTTkRxQrY1H9kz8YPFjE4Npe9J540uxT4tUb5kTP1Cs+xJCjxKcqIVPZtRkrLw/1pUM5vKxg4a3I2GYFLmHoQ==
+  dependencies:
+    react-wonka "^2.0.1"
+    scheduler ">= 0.16.0"
+    wonka "^4.0.7"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -10306,6 +10337,11 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wonka@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.7.tgz#b4934685bd2449367bd72ce7770bfe3e6cc8a68b"
+  integrity sha512-Uhyl2cgWCUksYtU0Jt8MSzKUqK4BVUrewWxnn1YlKL3Zco4sDcCUDkbgH0i762HJs1rtsq03cfzsCWxJKaDgVg==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
I did a typeof check on the body, because it's being sent through as a string. Not entirely convinced that would be the same for apollo-client as well. That's something we'd need to look into.